### PR TITLE
Change package.d module definition

### DIFF
--- a/source/derelict/sdl2/package.d
+++ b/source/derelict/sdl2/package.d
@@ -1,4 +1,4 @@
-module derelict.sdl2;
+module sdl2;
 
 public import derelict.sdl2.image,
               derelict.sdl2.mixer,


### PR DESCRIPTION
Compiling with dub build yielded the following error:
Error: module derelict.sdl2 from file source/derelict/sdl2/package.d conflicts with package name sdl2
This change got the library to compile on my Mac.
I do not know if this is the correct change, but here you have it, in case it helps.
