### PR TITLE
Remove stray refs to libSDL2.so in mixer + ttf.

### DIFF
--- a/source/derelict/sdl2/mixer.d
+++ b/source/derelict/sdl2/mixer.d
@@ -38,7 +38,7 @@ private {
     else static if( Derelict_OS_Mac )
         enum libNames = "../Frameworks/SDL2_mixer.framework/SDL2_mixer, /Library/Frameworks/SDL2_mixer.framework/SDL2_mixer, /System/Library/Frameworks/SDL2_mixer.framework/SDL2_mixer";
     else static if( Derelict_OS_Posix )
-        enum libNames = "libSDL2_mixer.so, libSDL2_mixer-2.0.so, libSDL2_mixer-2.0.so.0, /usr/local/lib/libSDL2.so, /usr/local/lib/libSDL2_mixer-2.0.so, /usr/local/lib/libSDL2_mixer-2.0.so.0";
+        enum libNames = "libSDL2_mixer.so, libSDL2_mixer-2.0.so, libSDL2_mixer-2.0.so.0, /usr/local/lib/libSDL2_mixer-2.0.so, /usr/local/lib/libSDL2_mixer-2.0.so.0";
     else
         static assert( 0, "Need to implement SDL2_mixer libNames for this operating system." );
 }

--- a/source/derelict/sdl2/ttf.d
+++ b/source/derelict/sdl2/ttf.d
@@ -40,7 +40,7 @@ private {
     else static if( Derelict_OS_Mac )
         enum libNames = "../Frameworks/SDL2_ttf.framework/SDL2_ttf, /Library/Frameworks/SDL2_ttf.framework/SDL2_ttf, /System/Library/Frameworks/SDL2_ttf.framework/SDL2_ttf";
     else static if( Derelict_OS_Posix )
-        enum libNames = "libSDL2_ttf.so, libSDL2_ttf-2.0.so, libSDL2_ttf-2.0.so.0, /usr/local/lib/libSDL2.so, /usr/local/lib/libSDL2_ttf-2.0.so, /usr/local/lib/libSDL2_ttf-2.0.so.0";
+        enum libNames = "libSDL2_ttf.so, libSDL2_ttf-2.0.so, libSDL2_ttf-2.0.so.0, /usr/local/lib/libSDL2_ttf-2.0.so, /usr/local/lib/libSDL2_ttf-2.0.so.0";
     else
         static assert( 0, "Need to implement SDL2_ttf libNames for this operating system." );
 }


### PR DESCRIPTION
Discussed with mathstuff on irc. Loader was looking for TTF symbols in libSDL2.so.

http://dpaste.dzfl.pl/11c5c17363ca
