### PR TITLE
Fixing OS versions to match latest DerelictUtil.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "targetPath": "lib",
 
     "dependencies": {
-        "derelict-util": ">=1.0.0"
+        "derelict-util": "~master"
     }
 }

--- a/source/derelict/sdl2/functions.d
+++ b/source/derelict/sdl2/functions.d
@@ -425,7 +425,7 @@ extern( C ) nothrow {
         alias da_SDL_RenderGetD3D9Device = IDirect3DDevice9* function( SDL_Renderer* );
         alias da_SDL_DXGIGetOutputInfo = void function ( int, int*, int* );
     }
-    static if( Derelict_OS_iOS ) {
+    static if( Derelict_OS_Mac ) {
         alias da_SDL_iPhoneSetAnimationCallback = int function( SDL_Window*, int, SDL_iPhoneAnimationCallback, void* );
         alias da_SDL_iPhoneSetEventPump = void function( SDL_bool );
     }
@@ -437,7 +437,7 @@ extern( C ) nothrow {
         alias da_SDL_AndroidGetInternalStorageState = int function();
         alias da_SDL_AndroidGetExternalStoragePath = const( char )* function();
     }
-    static if( Derelict_OS_WindowsRT ) {
+    static if( Derelict_OS_Windows ) {
         alias da_SDL_WinRTGetFSPathUNICODE = const( wchar_t )* function( SDL_WinRT_Path );
         alias da_SDL_WinRTGetFSPathUTF8 = const( char )* function( SDL_WinRT_Path );
     }
@@ -924,7 +924,7 @@ __gshared {
         da_SDL_RenderGetD3D9Device SDL_RenderGetD3D9Device;
         da_SDL_DXGIGetOutputInfo SDL_DXGIGetOutputInfo;
     }
-    static if( Derelict_OS_iOS ) {
+    static if( Derelict_OS_Mac ) {
         da_SDL_iPhoneSetAnimationCallback SDL_iPhoneSetAnimationCallback;
         da_SDL_iPhoneSetEventPump SDL_iPhoneSetEventPump;
     }
@@ -936,7 +936,7 @@ __gshared {
         da_SDL_AndroidGetInternalStorageState SDL_AndroidGetInternalStorageState;
         da_SDL_AndroidGetExternalStoragePath SDL_AndroidGetExternalStoragePath;
     }
-    static if( Derelict_OS_WindowsRT ) {
+    static if( Derelict_OS_Windows ) {
         da_SDL_WinRTGetFSPathUNICODE SDL_WinRTGetFSPathUNICODE;
         da_SDL_WinRTGetFSPathUTF8 SDL_WinRTGetFSPathUTF8;
     }

--- a/source/derelict/sdl2/sdl.d
+++ b/source/derelict/sdl2/sdl.d
@@ -391,7 +391,7 @@ class DerelictSDL2Loader : SharedLibLoader {
                 bindFunc( cast( void** )&SDL_RenderGetD3D9Device, "SDL_RenderGetD3D9Device" );
                 bindFunc( cast( void** )&SDL_DXGIGetOutputInfo, "SDL_DXGIGetOutputInfo" );
             }
-            static if( Derelict_OS_iOS ) {
+            static if( Derelict_OS_Mac ) {
                 bindFunc( cast( void** )&SDL_iPhoneSetAnimationCallback, "SDL_iPhoneSetAnimationCallback" );
                 bindFunc( cast( void** )&SDL_iPhoneSetEventPump, "SDL_iPhoneSetEventPump" );
             }
@@ -403,7 +403,7 @@ class DerelictSDL2Loader : SharedLibLoader {
                 bindFunc( cast( void** )&SDL_AndroidGetInternalStorageState, "SDL_AndroidGetInternalStorageState" );
                 bindFunc( cast( void** )&SDL_AndroidGetExternalStoragePath, "SDL_AndroidGetExternalStoragePath" );
             }
-            static if( Derelict_OS_WindowsRT ) {
+            static if( Derelict_OS_Windows ) {
                 bindFunc( cast( void** )&SDL_WinRTGetFSPathUNICODE, "SDL_WinRTGetFSPathUNICODE" );
                 bindFunc( cast( void** )&SDL_WinRTGetFSPathUTF8, "SDL_WinRTGetFSPathUTF8" );
             }

--- a/source/derelict/sdl2/types.d
+++ b/source/derelict/sdl2/types.d
@@ -1922,14 +1922,14 @@ extern( C ) nothrow alias SDL_blit = int function( SDL_Surface* src, SDL_Rect* s
 static if( Derelict_OS_Windows ) {
     struct IDirect3DDevice9;
 }
-static if( Derelict_OS_iOS ) {
+static if( Derelict_OS_Mac ) {
     extern( C ) nothrow alias SDL_iPhoneAnimationCallback = void function( void* );
 }
 static if( Derelict_OS_Android ) {
     enum int SDL_ANDROID_EXTERNAL_STORAGE_READ  = 0x01;
     enum int SDL_ANDROID_EXTERNAL_STORAGE_WRITE = 0x02;
 }
-static if( Derelict_OS_WindowsRT ) {
+static if( Derelict_OS_Windows ) {
     enum SDL_WinRT_Path {
         SDL_WINRT_PATH_INSTALLED_LOCATION,
         SDL_WINRT_PATH_LOCAL_FOLDER,


### PR DESCRIPTION
Original issue: https://github.com/DerelictOrg/DerelictSDL2/issues/16

Major points:
- There is no more Derelict_OS_WindowsRT.
- Depend on master DerelictUtil to get Android version flag.
- Derelict_OS_iOS is now Derelict_OS_Mac.
