### PR TITLE
made SDL_MUSTLOCK() const and pure

### DIFF
--- a/source/derelict/sdl2/types.d
+++ b/source/derelict/sdl2/types.d
@@ -1918,7 +1918,7 @@ enum {
     SDL_DONTFREE = 0x00000004,
 }
 
-bool SDL_MUSTLOCK( const SDL_Surface* S ) pure { return ( S.flags & SDL_RLEACCEL ) != 0; }
+bool SDL_MUSTLOCK( const SDL_Surface* S ) { return ( S.flags & SDL_RLEACCEL ) != 0; }
 
 struct SDL_BlitMap;
 struct SDL_Surface {


### PR DESCRIPTION
This allows SDL_MUSTLOCK to be used in contracts and other scenarios where const is needed
