### PR TITLE
Added missing SDL_RenderSetClipRect & SDL_RenderGetClipRect bindings.

### DIFF
--- a/source/derelict/sdl2/functions.d
+++ b/source/derelict/sdl2/functions.d
@@ -331,6 +331,8 @@ extern( C ) @nogc nothrow {
     alias da_SDL_RenderTargetSupported = SDL_bool function( SDL_Renderer* );
     alias da_SDL_SetRenderTarget = int function( SDL_Renderer*, SDL_Texture* );
     alias da_SDL_GetRenderTarget = SDL_Texture* function( SDL_Renderer* );
+    alias da_SDL_RenderSetClipRect = int function( SDL_Renderer*, const( SDL_Rect )* );
+    alias da_SDL_RenderGetClipRect = void function( SDL_Renderer* renderer, SDL_Rect* );
     alias da_SDL_RenderSetLogicalSize = int function( SDL_Renderer*, int, int );
     alias da_SDL_RenderGetLogicalSize = void function( SDL_Renderer*, int*, int* );
     alias da_SDL_RenderSetViewport = int function( SDL_Renderer*, const( SDL_Rect )* );
@@ -849,6 +851,8 @@ __gshared {
     da_SDL_RenderTargetSupported SDL_RenderTargetSupported;
     da_SDL_SetRenderTarget SDL_SetRenderTarget;
     da_SDL_GetRenderTarget SDL_GetRenderTarget;
+    da_SDL_RenderSetClipRect SDL_RenderSetClipRect;
+    da_SDL_RenderGetClipRect SDL_RenderGetClipRect;
     da_SDL_RenderSetLogicalSize SDL_RenderSetLogicalSize;
     da_SDL_RenderGetLogicalSize SDL_RenderGetLogicalSize;
     da_SDL_RenderSetViewport SDL_RenderSetViewport;

--- a/source/derelict/sdl2/sdl.d
+++ b/source/derelict/sdl2/sdl.d
@@ -310,6 +310,8 @@ class DerelictSDL2Loader : SharedLibLoader {
             bindFunc( cast( void** )&SDL_RenderTargetSupported, "SDL_RenderTargetSupported" );
             bindFunc( cast( void** )&SDL_SetRenderTarget, "SDL_SetRenderTarget" );
             bindFunc( cast( void** )&SDL_GetRenderTarget, "SDL_GetRenderTarget" );
+            bindFunc( cast( void** )&SDL_RenderSetClipRect, "SDL_RenderSetClipRect" );
+            bindFunc( cast( void** )&SDL_RenderGetClipRect, "SDL_RenderGetClipRect" );
             bindFunc( cast( void** )&SDL_RenderSetLogicalSize, "SDL_RenderSetLogicalSize" );
             bindFunc( cast( void** )&SDL_RenderGetLogicalSize, "SDL_RenderGetLogicalSize" );
             bindFunc( cast( void** )&SDL_RenderSetViewport, "SDL_RenderSetViewport" );


### PR DESCRIPTION
Hello!
Great respect for your work on Derelict.
I need these functions in SDL2 bindings, so please accept my pull reguest if this is all right.
Sorry for bad English.