### PR TITLE
Fixed TTF font face indexes being int instead of long

### DIFF
--- a/source/derelict/sdl2/ttf.d
+++ b/source/derelict/sdl2/ttf.d
@@ -91,9 +91,9 @@ extern ( C ) @nogc nothrow {
     alias da_TTF_ByteSwappedUNICODE = void function( int );
     alias da_TTF_Init = int function();
     alias da_TTF_OpenFont = TTF_Font * function ( const( char )*, int );
-    alias da_TTF_OpenFontIndex = TTF_Font * function ( const( char )*, int, c_long  );
+    alias da_TTF_OpenFontIndex = TTF_Font * function ( const( char )*, int, long );
     alias da_TTF_OpenFontRW = TTF_Font * function ( SDL_RWops*, int, int );
-    alias da_TTF_OpenFontIndexRW = TTF_Font * function ( SDL_RWops*, int, int, c_long );
+    alias da_TTF_OpenFontIndexRW = TTF_Font * function ( SDL_RWops*, int, int, long );
     alias da_TTF_GetFontStyle = int function ( const( TTF_Font )* );
     alias da_TTF_SetFontStyle = void function ( const( TTF_Font )*, int style );
     alias da_TTF_GetFontOutline = int function( const( TTF_Font )* );
@@ -106,7 +106,7 @@ extern ( C ) @nogc nothrow {
     alias da_TTF_FontLineSkip = int function( const( TTF_Font )* );
     alias da_TTF_GetFontKerning = int function( const( TTF_Font )* );
     alias da_TTF_SetFontKerning = void function( TTF_Font*, int );
-    alias da_TTF_FontFaces = int function( const( TTF_Font )* );
+    alias da_TTF_FontFaces = long function( const( TTF_Font )* );
     alias da_TTF_FontFaceIsFixedWidth = int function( const( TTF_Font )* );
     alias da_TTF_FontFaceFamilyName = char* function( const( TTF_Font )* );
     alias da_TTF_FontFaceStyleName = char* function( const( TTF_Font )* );


### PR DESCRIPTION
The c_long alias currently used maps to int, but the SDL documentation distinguishes between these functions' int and long arguments and return values. I'm _pretty_ sure these should actually be normal longs.

c_long is aliased to int on lines 53 (windows) and 84 (posix)
https://github.com/dlang/druntime/blob/master/src/core/stdc/config.d

And the TTF functions this pertains to
- TTF_OpenFontIndex: https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf_16.html
- TTF_OpenFontIndexRW: https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf_17.html
- TTF_FontFaces: https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf_33.html