### PR TITLE
Add extra libNames for OSX

### DIFF
--- a/source/derelict/sdl2/internal/sdl_dynload.d
+++ b/source/derelict/sdl2/internal/sdl_dynload.d
@@ -675,7 +675,7 @@ private:
       static if(Derelict_OS_Windows)
         enum libNames = "SDL2.dll";
       else static if(Derelict_OS_Mac)
-        enum libNames = "/usr/local/lib/libSDL2.dylib, /usr/local/lib/libSDL2/libSDL2.dylib, ../Frameworks/SDL2.framework/SDL2, /Library/Frameworks/SDL2.framework/SDL2, /System/Library/Frameworks/SDL2.framework/SDL2";
+        enum libNames = "libSDL2.dylib, /usr/local/lib/libSDL2.dylib, /usr/local/lib/libSDL2/libSDL2.dylib, ../Frameworks/SDL2.framework/SDL2, /Library/Frameworks/SDL2.framework/SDL2, /System/Library/Frameworks/SDL2.framework/SDL2, /opt/local/lib/libSDL2.dylib";
       else static if(Derelict_OS_Posix)
         enum libNames = "libSDL2.so, libSDL2-2.0.so, libSDL2-2.0.so.0, /usr/local/lib/libSDL2.so, /usr/local/lib/libSDL2-2.0.so, /usr/local/lib/libSDL2-2.0.so.0";
       else


### PR DESCRIPTION
This adds `libSDL2.dylib` and `/opt/local/lib/libSDL2.dylib` to the search path for the SDL2 shared library on OSX.
I've given priority to finding `libSDL2.dylib` (without relative/absolute path) first, e.g. next to the executable. I've appended the installation path where SDL is installed by Macports.

(sorry for including the extra newline at the end (shame! ;-), I think the Github UI automatically added it)