### PR TITLE
Fixes the second argument for SDL_Vulkan_GetInstanceExtensions

### DIFF
--- a/source/derelict/sdl2/internal/sdl_dynamic.d
+++ b/source/derelict/sdl2/internal/sdl_dynamic.d
@@ -590,7 +590,7 @@ extern(C) @nogc nothrow {
     alias da_SDL_Vulkan_LoadLibrary = int function(const(char)*);
     alias da_SDL_Vulkan_GetVkGetInstanceProcAddr = void* function();
     alias da_SDL_Vulkan_UnloadLibrary = void function();
-    alias da_SDL_Vulkan_GetInstanceExtensions = SDL_bool function(SDL_Window*,uint,const(char)**);
+    alias da_SDL_Vulkan_GetInstanceExtensions = SDL_bool function(SDL_Window*,uint*,const(char)**);
     alias da_SDL_Vulkan_CreateSurface = SDL_bool function(SDL_Window*,void*,void*);
     alias da_SDL_Vulkan_GetDrawableSize = void function(SDL_Window*,int*,int*);
 }

--- a/source/derelict/sdl2/internal/sdl_static.d
+++ b/source/derelict/sdl2/internal/sdl_static.d
@@ -589,7 +589,7 @@ extern(C) @nogc nothrow {
     int SDL_Vulkan_LoadLibrary(const(char)*);
     void* SDL_Vulkan_GetVkGetInstanceProcAddr();
     void SDL_Vulkan_UnloadLibrary();
-    SDL_bool SDL_Vulkan_GetInstanceExtensions(SDL_Window*,uint,const(char)**);
+    SDL_bool SDL_Vulkan_GetInstanceExtensions(SDL_Window*,uint*,const(char)**);
     SDL_bool SDL_Vulkan_CreateSurface(SDL_Window*,void*,void*);
     void SDL_Vulkan_GetDrawableSize(SDL_Window*,int*,int*);
 }


### PR DESCRIPTION
The second argument for SDL_Vulkan_GetInstanceExtensions is wrong, it is an `uint*` not an `uint`.

https://github.com/SDL-mirror/SDL/blob/b5951c6fa2330021bc8a81104747b6cdcbd6fc0b/include/SDL_vulkan.h#L189..192